### PR TITLE
del: mackerel-agent rootdir

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "tomohiro-mackerel_agent",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "author": "Tomohiro TAIRA",
   "summary": "Install and configure mackerel-agent",
   "license": "Apache-2.0",

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -3,7 +3,6 @@
 #
 apikey = "<%= @apikey %>"
 pidfile = "./pid"
-root = "."
 verbose = false
 
 <% if @roles %>


### PR DESCRIPTION
Delete this line.

The reason is that because of this setting we will not see where we want to reference.
 Looking at the official settings now there is a default setting even if you do not specify directly basically.
