### PR TITLE
add --upgrade oprion to `mkr plugin install`

### DIFF
--- a/manifests/mkr_plugin.pp
+++ b/manifests/mkr_plugin.pp
@@ -9,10 +9,9 @@ define mackerel_agent::mkr_plugin {
   }
 
   exec { "mkr plugin install ${name}":
-    command => "mkr plugin install ${name}",
+    command => "mkr plugin install --upgrade ${name}",
     user    => 'root',
     path    => ['/usr/bin'],
-    creates => "/opt/mackerel-agent/plugins/bin/${name}",
     require => Package['mkr']
   }
 


### PR DESCRIPTION
> This option allows you to avoid meaningless downloads. We recommend adding in this upgrade option when performing plugin installation with provisioning tools.
> 
> You can also use the upgrade option to downgrade. For example, if v.0.0.2 is currently installed and v0.0.1 is then specified and executed, v0.0.1 will be installed. 

ref: https://mackerel.io/ja/docs/entry/advanced/install-plugin-by-mkr