### PR TITLE
Use default parameter for pidfile

### DIFF
--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -2,7 +2,6 @@
 #   https://github.com/mackerelio/mackerel-agent/blob/master/mackerel-agent.sample.conf
 #
 apikey = "<%= @apikey %>"
-pidfile = "./pid"
 verbose = false
 
 <% if @roles %>


### PR DESCRIPTION
A pid file is created directly under /.
In default, it is created in /var/run/mackerel-agent.pid, so respect that.