### PR TITLE
Require only the minimum version.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 <5.0.0"
+      "version_requirement": ">= 3.2.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <5.0.0"
+      "version_requirement": ">=2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
If the highest version is specified, it often causes conflict.
It does not happen if you specify only the minimum version.