### PR TITLE
Add unless parameter to Exec[mkr plugin install $name].

### DIFF
--- a/manifests/mkr_plugin.pp
+++ b/manifests/mkr_plugin.pp
@@ -2,6 +2,9 @@
 #
 define mackerel_agent::mkr_plugin {
 
+  $install_location = '/opt/mackerel-agent/plugins'
+  $name_array = split($name, '@')
+
   include ::mackerel_agent
 
   if !defined(Package['mkr']) {
@@ -12,6 +15,7 @@ define mackerel_agent::mkr_plugin {
     command => "mkr plugin install --upgrade ${name}",
     user    => 'root',
     path    => ['/usr/bin'],
+    unless  => "test '${name_array[1]}' = '`cat ${install_location}/meta/${name_array[0]}/release_tag`'",
     require => Package['mkr']
   }
 


### PR DESCRIPTION
Executes the Exec resource only if the specified version is not installed.

The default plugin installation location for the mkr plugin command is specified below.
ref. https://github.com/mackerelio/mkr/blob/master/plugin/install.go#L24
