### PR TITLE
Not set if the hash value of the plug-in setting is "undef".

### DIFF
--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -35,8 +35,10 @@ ignore = "<%= @ignore_filesystems %>"
 #   help: http://help.mackerel.io/entry/howto/mackerel-agent-plugins
 #   repository: https://github.com/mackerelio/mackerel-agent-plugins
 <% @metrics_plugins.each do |plugin, command| %>
+<% unless command.nil? -%>
 [plugin.metrics.<%= plugin %>]
 command = "<%= command %>"
+<% end -%>
 <% end %>
 
 # Configuration for Custom Check Plugins
@@ -45,6 +47,7 @@ command = "<%= command %>"
 #   help: http://help.mackerel.io/entry/howto/mackerel-check-plugins
 #   repository: https://github.com/mackerelio/go-check-plugins
 <% @check_plugins.each do |plugin, parameters| %>
+<% unless parameters.nil? -%>
 [plugin.checks.<%= plugin %>]
 <% if parameters.is_a?(Hash) -%>
 <% parameters.each do |param, data| -%>
@@ -60,5 +63,6 @@ command = "<%= command %>"
 <% end -%>
 <% else -%>
 command = "<%= parameters %>"
+<% end -%>
 <% end -%>
 <% end %>


### PR DESCRIPTION
- e.g. it can be used when overwriting with hiera.