### PR TITLE
Using validate_legacy instead of obsoleted validate_* methods 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,23 +93,23 @@ class mackerel_agent(
   $use_mkr             = undef,
   $mkr_plugins         = {},
 ) {
-  validate_re($::osfamily, '^(RedHat|Debian)$', 'This module only works on RedHat or Debian based systems.')
-  validate_string($apikey)
-  validate_bool($service_enable)
-  validate_hash($metrics_plugins)
-  validate_hash($check_plugins)
-  validate_hash($mkr_plugins)
+  validate_legacy(Pattern[/^(RedHat|Debian)$/], 'validate_re', $::osfamily, ['^(RedHat|Debian)$'], 'This module only works on RedHat or Debian based systems.')
+  validate_legacy(String, 'validate_string', $apikey)
+  validate_legacy(Boolean, 'validate_bool', $service_enable)
+  validate_legacy(Hash, 'validate_hash', $metrics_plugins)
+  validate_legacy(Hash, 'validate_hash', $check_plugins)
+  validate_legacy(Hash, 'validate_hash', $mkr_plugins)
 
   if $roles != undef {
-    validate_array($roles)
+    validate_legacy(Array, 'validate_array', $roles)
   }
 
   if $host_status != undef {
-    validate_hash($host_status)
+    validate_legacy(Hash, 'validate_hash', $host_status)
   }
 
   if $ignore_filesystems != undef {
-    validate_string($ignore_filesystems)
+    validate_legacy(String, 'validate_string', $ignore_filesystems)
   }
 
   if $apikey == undef {


### PR DESCRIPTION
It is prefer to be replaced in class parameters.

At this time, solving warnings is things we want to do.