### PR TITLE
Support `env` option of plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,20 @@ class { 'mackerel_agent':
   },
   check_plugins       => {
     access_log => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL',
-    check_cron => '/usr/local/bin/check-procs -p crond'
+    check_cron => '/usr/local/bin/check-procs -p crond',
     check_ssh  => {
       command               => 'ruby /path/to/check-ssh.rb',
       notification_interval => '60',
       max_check_attempts    => '3',
       check_interval        => '5'
+    },
+    log => {
+      command => 'check-log -f /path/to/file -p PATTERN',
+      action => '{ command = "bash -c \'[ \"$MACKEREL_STATUS\" != \"OK\" ]\' && ruby /path/to/something.rb", user = "someone" }',
+    },
+    mysql => {
+      command => 'ruby /path/to/mysql.rb',
+      env => '{ "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }',
     }
   },
   mkr_plugins         => {
@@ -91,6 +99,14 @@ mackerel_agent::check_plugins:
     notification_interval: '60'
     max_check_attempts: '3'
     check_interval: '5'
+  log:
+    command: 'check-log -f /path/to/file -p PATTERN'
+    action: |
+      { command = "bash -c '[ \"$MACKEREL_STATUS\" != \"OK\" ]' && ruby /path/to/something.rb", user = "someone" }
+  mysql:
+    command: 'ruby /path/to/mysql.rb',
+    env: |
+      { "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }
 mackerel_agent::mkr_plugins:
   mackerel-plugin-sample: {}
   mackerel-plugin-json: {}

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -68,15 +68,27 @@ describe 'mackerel_agent::config' do
         { check_plugins: {
           'ssh' => {
             'command' => 'ruby /path/to/check-ssh.rb',
-            'action' => '{ command = "bash -c \'[ \"$MACKEREL_STATUS\" != \"OK\" ]\' && ruby /path/to/something.rb", user = "someone" }',
-            'notification_interval' => '6',
+            'notification_interval' => '60',
             'max_check_attempts' => '3',
             'check_interval' => '5',
           },
         } }
       end
 
-      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\naction = .*\nnotification_interval = .*\nmax_check_attempts = .*\ncheck_interval = .*$}) } # rubocop:disable Metrics/LineLength
+      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.ssh\]\ncommand = \"ruby \/path\/to\/check-ssh\.rb\"\nnotification_interval = 60\nmax_check_attempts = 3\ncheck_interval = 5$}) } # rubocop:disable Metrics/LineLength
+    end
+
+    context 'with check_plugins specify action param' do
+      let(:params) do
+        { check_plugins: {
+          'log' => {
+            'command' => 'check-log -f /path/to/file -p PATTERN',
+            'action' => '{ command = "bash -c \'[ \"$MACKEREL_STATUS\" != \"OK\" ]\' && ruby /path/to/something.rb", user = "someone" }',
+          },
+        } }
+      end
+
+      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.log\]\ncommand = "check-log -f \/path\/to\/file -p PATTERN"\naction = { command = "bash -c '\[ \\"\$MACKEREL_STATUS\\" != \\"OK\\" \]' && ruby \/path\/to\/something\.rb", user = "someone" }$}) }
     end
 
     context 'with check_plugins specify env param' do

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -78,5 +78,31 @@ describe 'mackerel_agent::config' do
 
       it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\naction = .*\nnotification_interval = .*\nmax_check_attempts = .*\ncheck_interval = .*$}) } # rubocop:disable Metrics/LineLength
     end
+
+    context 'with check_plugins specify env param' do
+      let(:params) do
+        { check_plugins: {
+          'mysql' => {
+            'command' => 'ruby /path/to/mysql.rb',
+            'env' => '{ "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }',
+          },
+        } }
+      end
+
+      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.mysql\]\ncommand = "ruby \/path\/to\/mysql\.rb"\nenv = { "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }$}) }
+    end
+
+    context 'with metrics_plugins specify env param' do
+      let(:params) do
+        { metrics_plugins: {
+          'mysql' => {
+            'command' => 'ruby /path/to/mysql.rb',
+            'env' => '{ "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }',
+          },
+        } }
+      end
+
+      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.metrics.mysql\]\ncommand = "ruby \/path\/to\/mysql.rb"\nenv = { "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }$}) }
+    end
   end
 end

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -61,18 +61,14 @@ command = "<%= command %>"
 [plugin.checks.<%= plugin %>]
 <% if parameters.is_a?(Hash) -%>
 <% parameters.each do |param, data| -%>
-<% if data =~ /^[0-9]+$/ -%>
-<%= param %> = <%= data %>
-<% else -%>
-<% if param == "action" or param == "env" -%>
+<% if data =~ /^[0-9]+$/ or param == "action" or param == "env" -%>
 <%= param %> = <%= data %>
 <% else -%>
 <%= param %> = "<%= data %>"
-<% end -%>
 <% end -%>
 <% end -%>
 <% else -%>
 command = "<%= parameters %>"
 <% end -%>
 <% end -%>
-<% end %>
+<% end -%>

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -34,12 +34,22 @@ ignore = "<%= @ignore_filesystems %>"
 # followings are mackerel-agent-plugins
 #   help: http://help.mackerel.io/entry/howto/mackerel-agent-plugins
 #   repository: https://github.com/mackerelio/mackerel-agent-plugins
-<% @metrics_plugins.each do |plugin, command| %>
-<% unless command.nil? -%>
+<% @metrics_plugins.each do |plugin, parameters| %>
+<% unless parameters.nil? -%>
 [plugin.metrics.<%= plugin %>]
+<% if parameters.is_a?(Hash) -%>
+<% parameters.each do |param, data| -%>
+<% if param == "env" -%>
+<%= param %> = <%= data %>
+<% else -%>
+<%= param %> = "<%= data %>"
+<% end -%>
+<% end -%>
+<% else -%>
 command = "<%= command %>"
 <% end -%>
-<% end %>
+<% end -%>
+<% end -%>
 
 # Configuration for Custom Check Plugins
 #
@@ -54,7 +64,7 @@ command = "<%= command %>"
 <% if data =~ /^[0-9]+$/ -%>
 <%= param %> = <%= data %>
 <% else -%>
-<% if param == "action" -%>
+<% if param == "action" or param == "env" -%>
 <%= param %> = <%= data %>
 <% else -%>
 <%= param %> = "<%= data %>"


### PR DESCRIPTION
If the parameter key is `env`, do not enclose the value `data` in quotation marks.
- https://mackerel.io/blog/entry/weekly/20171215
- https://mackerel.io/docs/entry/spec/agent