### PR TITLE
Fix unit test ( apt modules require more fact params )

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [dummy]
+        ruby-version: [dummy]
+        puppet-version: [dummy]
+        check: [dummy]
+        include:
+          - os: ubuntu-16.04
+            ruby-version: 2.6
+            puppet-version: '~> 6.0'
+            check: ''
+          - os: ubuntu-18.04
+            ruby-version: 2.6
+            puppet-version: '~> 6.0'
+            check: ''
+          - os: ubuntu-20.04
+            ruby-version: 2.6
+            puppet-version: '~> 6.0'
+            check: ''
+          - os: ubuntu-18.04
+            ruby-version: 2.6
+            puppet-version: '~> 6.0'
+            check: 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
+          - os: ubuntu-18.04
+            ruby-version: 2.3.8
+            puppet-version: '~> 4.0'
+            check: parallel_spec
+          - os: ubuntu-18.04
+            ruby-version: 2.4.9
+            puppet-version: '~> 5.0'
+            check: parallel_spec
+          - os: ubuntu-18.04
+            ruby-version: 2.5.7
+            puppet-version: '~> 5.0'
+            check: parallel_spec
+        exclude:
+          - os: dummy
+            ruby-version: dummy
+            puppet-version: dummy
+            check: dummy
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+      env:
+        PUPPET_GEM_VERSION: ${{ matrix.puppet-version }}
+    - name: Run tests
+      run: bundle exec rake $CHECK
+      env:
+        CHECK: ${{ matrix.check }}
+  centos:
+    runs-on: ubuntu-latest
+    container: ghcr.io/k1low/centve:latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      run: |
+        anyenv-init
+        rbenv global 2.7.3
+    - name: Run tests
+      run: |
+        gem install bundler
+        bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,17 @@ jobs:
         CHECK: ${{ matrix.check }}
   centos:
     runs-on: ubuntu-latest
-    container: ghcr.io/k1low/centve:latest
+    container: ghcr.io/k1low/centve:7-base
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       run: |
         anyenv-init
-        rbenv global 2.7.3
+        anyenv install rbenv -f
+        rbenv install 2.6.7
+        rbenv global 2.6.7
     - name: Run tests
       run: |
         gem install bundler
+        bundle install
         bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.4'
   Include:
   - "./**/*.rb"
   Exclude:
@@ -19,10 +19,6 @@ AllCops:
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -63,7 +59,7 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -86,7 +82,7 @@ Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/spec/defines/mkr_plugin_spec.rb
+++ b/spec/defines/mkr_plugin_spec.rb
@@ -30,9 +30,13 @@ describe 'mackerel_agent::mkr_plugin' do
         operatingsystemmajrelease: '9',
         os: {
           'name' => 'Debian',
+          'family' => 'Debian',
           'release' => {
             'full' => '9',
             'major' => '9',
+          },
+          'distro' => {
+            'codename' => 'stretch',
           },
         },
       }


### PR DESCRIPTION
The apt module used for testing needs more `facts` information, so add it.

```
mackerel_agent::mkr_plugin
  on RedHat has been supported
    is expected to compile into a catalogue without dependency cycles
  on Debian has been supported
    is expected to compile into a catalogue without dependency cycles (FAILED - 1)

Failures:

  1) mackerel_agent::mkr_plugin on Debian has been supported is expected to compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, This module only works on Debian or derivatives like Ubuntu (file:
/Users/k1low/src/github.com/pepabo/puppet-mackerel_agent/spec/fixtures/modules/apt/manifests/params.pp, line: 8, column: 5) (file: /Users/k1low/src/github.com/pepabo/puppet-mackerel_agent/spec/fixtures/modules/mackerel_ag
ent/manifests/install.pp, line: 68) on node pmac776s.gmo.local
     # ./spec/defines/mkr_plugin_spec.rb:41:in `block (3 levels) in <top (required)>'
```

And, since the CI environment was not running, enabled GitHub Actions.
