### PR TITLE
check-plugins setting support boolean parameters

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -72,11 +72,12 @@ describe 'mackerel_agent::config' do
             'notification_interval' => '6',
             'max_check_attempts' => '3',
             'check_interval' => '5',
+            'prevent_alert_auto_close' => true,
           },
         } }
       end
 
-      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\naction = .*\nnotification_interval = .*\nmax_check_attempts = .*\ncheck_interval = .*$}) } # rubocop:disable Metrics/LineLength
+      it { is_expected.to contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\naction = .*\nnotification_interval = 6\nmax_check_attempts = 3\ncheck_interval = 5\nprevent_alert_auto_close = true.*$}) } # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -53,6 +53,8 @@ command = "<%= command %>"
 <% parameters.each do |param, data| -%>
 <% if data =~ /^[0-9]+$/ -%>
 <%= param %> = <%= data %>
+<% elsif data.is_a?(FalseClass) || data.is_a?(TrueClass) -%>
+<%= param %> = <%= data %>
 <% else -%>
 <% if param == "action" -%>
 <%= param %> = <%= data %>


### PR DESCRIPTION
check-plugins has parameters that are set by boolean values, such as `prevent_alert_auto_close` .
This PR supports the above.