### PR TITLE
remove `/etc/mackerel-agent/conf.d` forcibly when `ensure => absent`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,13 +11,19 @@ class mackerel_agent::config(
 ) {
 
   if $ensure == present {
-    $directory_ensure = directory
+    $directory_ensure  = directory
+    $directory_recurse = false
+    $directory_force   = false
   } else {
-    $directory_ensure = absent
+    $directory_ensure  = absent
+    $directory_recurse = true
+    $directory_force   = true
   }
 
   file { '/etc/mackerel-agent/conf.d':
     ensure  => $directory_ensure,
+    recurse => $directory_recurse,
+    force   => $directory_force,
     require => Package['mackerel-agent']
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,10 @@ class mackerel_agent::config(
     $directory_force   = true
   }
 
-  file { '/etc/mackerel-agent/conf.d':
+  file { [
+      '/etc/mackerel-agent',
+      '/etc/mackerel-agent/conf.d',
+    ]:
     ensure  => $directory_ensure,
     recurse => $directory_recurse,
     force   => $directory_force,


### PR DESCRIPTION
When there are any files or directories in `/etc/mackerel-agent/conf.d` , `/etc/mackerel-agent/conf.d` cannot be removed even if `ensure => absent`.
I'll fix it.

```
Warning: /Stage[main]/Mackerel_agent::Config/File[/etc/mackerel-agent/conf.d]: Could not back up file of type directory
Notice: /Stage[main]/Mackerel_agent::Config/File[/etc/mackerel-agent/conf.d]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Mackerel_agent::Config/File[/etc/mackerel-agent/conf.d]/ensure: removed (corrective)
```