### PR TITLE
Remove quotes from Integer and Float values

### DIFF
--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -51,7 +51,7 @@ command = "<%= command %>"
 [plugin.checks.<%= plugin %>]
 <% if parameters.is_a?(Hash) -%>
 <% parameters.each do |param, data| -%>
-<% if data =~ /^[0-9]+$/ -%>
+<% if data.is_a?(Integer) || data.is_a?(Float) || data =~ /^[0-9]+$/ -%>
 <%= param %> = <%= data %>
 <% elsif data.is_a?(FalseClass) || data.is_a?(TrueClass) -%>
 <%= param %> = <%= data %>


### PR DESCRIPTION
IntegerやFloatで値を指定するとクォートされてしまう。
例えば `max_check_attemps: 3` とするとmackerel-agent.confに `max_check_attemps = "3"`と出力されinvalid typeとなってしまう。
このPRの変更で、IntegerやFloatをクォートせずに出力するようになる。